### PR TITLE
Added a system allowing to set destination for carts to enable routing in train-networks

### DIFF
--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/CartRouting.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/CartRouting.java
@@ -19,7 +19,7 @@ public class CartRouting extends TweakCartPlugin {
     public void registerEvents(TweakPluginManager pluginManager) {
         pluginManager.registerEvent(DetectorRailListener.getInstance(), TweakCartEvent.Block.VehicleBlockRedstoneEvent);
 
-        pluginManager.registerEvent(new CartRoutingEventListener(this), TweakCartEvent.Sign.VehiclePassesSignEvent, "set destination", "get destination", "read destination");
+        pluginManager.registerEvent(new CartRoutingEventListener(this), TweakCartEvent.Sign.VehiclePassesSignEvent, "set destination", "get destination", "read destination", "clear destination");
     }
 
 }

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/CartRouting.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/CartRouting.java
@@ -1,0 +1,25 @@
+package net.tweakcraft.tweakcart.cartrouting;
+
+import net.tweakcraft.tweakcart.TweakCart;
+import net.tweakcraft.tweakcart.api.model.TweakCartEvent;
+import net.tweakcraft.tweakcart.api.model.TweakCartPlugin;
+import net.tweakcraft.tweakcart.cartrouting.listener.CartRoutingEventListener;
+import net.tweakcraft.tweakcart.cartrouting.listener.DetectorRailListener;
+import net.tweakcraft.tweakcart.util.TweakPluginManager;
+
+/**
+ * Created by nick on 25/03/2015.
+ */
+public class CartRouting extends TweakCartPlugin {
+
+    @Override
+    public String getPluginName() { return "CartRouting"; }
+
+    @Override
+    public void registerEvents(TweakPluginManager pluginManager) {
+        pluginManager.registerEvent(DetectorRailListener.getInstance(), TweakCartEvent.Block.VehicleBlockRedstoneEvent);
+
+        pluginManager.registerEvent(new CartRoutingEventListener(this), TweakCartEvent.Sign.VehiclePassesSignEvent, "set destination", "get destination");
+    }
+
+}

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/CartRouting.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/CartRouting.java
@@ -19,7 +19,7 @@ public class CartRouting extends TweakCartPlugin {
     public void registerEvents(TweakPluginManager pluginManager) {
         pluginManager.registerEvent(DetectorRailListener.getInstance(), TweakCartEvent.Block.VehicleBlockRedstoneEvent);
 
-        pluginManager.registerEvent(new CartRoutingEventListener(this), TweakCartEvent.Sign.VehiclePassesSignEvent, "set destination", "get destination");
+        pluginManager.registerEvent(new CartRoutingEventListener(this), TweakCartEvent.Sign.VehiclePassesSignEvent, "set destination", "get destination", "read destination");
     }
 
 }

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/HelperClass.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/HelperClass.java
@@ -12,20 +12,15 @@ public class HelperClass {
 
     public static Sign findSign(Block block, String firstLine){
         int[][] locations = { {1,0}, {0,1}, {-1,0}, {0,-1} }; /* A diff in every direction from the origin */
-        System.out.println("FindSign!");
-        System.out.println(block.getType().name());
 
-        for(int[] diff : locations) {
+        for(int[] diff : locations)
             if (BlockUtil.isSign(block.getRelative(diff[0], 0, diff[1]))){
                 Sign sign = (Sign) block.getRelative(diff[0], 0, diff[1]).getState();
                 if(sign.getLine(0).equalsIgnoreCase(ActionType.GETDEST.getText()))
                     return sign;
                 else return null;
-            } else
-                System.out.println(block.getRelative(diff[0], 0, diff[1]).getType().name());
-        }
-        System.out.println("End FindSign!");
+            }
+
         return null;
     }
-
 }

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/HelperClass.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/HelperClass.java
@@ -1,5 +1,6 @@
 package net.tweakcraft.tweakcart.cartrouting;
 
+import net.tweakcraft.tweakcart.cartrouting.model.ActionType;
 import net.tweakcraft.tweakcart.util.BlockUtil;
 import org.bukkit.block.Block;
 import org.bukkit.block.Sign;
@@ -9,15 +10,18 @@ import org.bukkit.block.Sign;
  */
 public class HelperClass {
 
-    public static Sign findSign(Block block){
+    public static Sign findSign(Block block, String firstLine){
         int[][] locations = { {1,0}, {0,1}, {-1,0}, {0,-1} }; /* A diff in every direction from the origin */
         System.out.println("FindSign!");
         System.out.println(block.getType().name());
 
-        for(int[] diff : locations){
-            if(BlockUtil.isSign(block.getRelative(diff[0], 0, diff[1])))
-                return (Sign) block.getRelative(diff[0], 0, diff[1]).getState();
-            else
+        for(int[] diff : locations) {
+            if (BlockUtil.isSign(block.getRelative(diff[0], 0, diff[1]))){
+                Sign sign = (Sign) block.getRelative(diff[0], 0, diff[1]).getState();
+                if(sign.getLine(0).equalsIgnoreCase(ActionType.GETDEST.getText()))
+                    return sign;
+                else return null;
+            } else
                 System.out.println(block.getRelative(diff[0], 0, diff[1]).getType().name());
         }
         System.out.println("End FindSign!");

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/HelperClass.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/HelperClass.java
@@ -1,0 +1,27 @@
+package net.tweakcraft.tweakcart.cartrouting;
+
+import net.tweakcraft.tweakcart.util.BlockUtil;
+import org.bukkit.block.Block;
+import org.bukkit.block.Sign;
+
+/**
+ * Created by nick on 26/03/2015.
+ */
+public class HelperClass {
+
+    public static Sign findSign(Block block){
+        int[][] locations = { {1,0}, {0,1}, {-1,0}, {0,-1} }; /* A diff in every direction from the origin */
+        System.out.println("FindSign!");
+        System.out.println(block.getType().name());
+
+        for(int[] diff : locations){
+            if(BlockUtil.isSign(block.getRelative(diff[0], 0, diff[1])))
+                return (Sign) block.getRelative(diff[0], 0, diff[1]).getState();
+            else
+                System.out.println(block.getRelative(diff[0], 0, diff[1]).getType().name());
+        }
+        System.out.println("End FindSign!");
+        return null;
+    }
+
+}

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/CartRoutingEventListener.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/CartRoutingEventListener.java
@@ -5,6 +5,7 @@ import net.tweakcraft.tweakcart.api.event.listeners.TweakSignEventListener;
 import net.tweakcraft.tweakcart.cartrouting.model.ActionType;
 import net.tweakcraft.tweakcart.util.BlockUtil;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.material.DetectorRail;
 import org.bukkit.material.Lever;
 import org.bukkit.metadata.FixedMetadataValue;
@@ -35,6 +36,10 @@ public class CartRoutingEventListener extends TweakSignEventListener {
                         DetectorRailListener.getInstance().activate(event.getMinecart().getLocation().getBlock().getLocation());
                     }
                 }
+                break;
+            case READDEST:
+                if(event.getMinecart().hasMetadata("Destination") && event.getMinecart().getPassenger() instanceof Player)
+                    ((Player) event.getMinecart().getPassenger()).sendMessage("Your are travelling to: " + event.getMinecart().getMetadata("Destination").get(0).asString());
                 break;
         }
     }

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/CartRoutingEventListener.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/CartRoutingEventListener.java
@@ -1,0 +1,44 @@
+package net.tweakcraft.tweakcart.cartrouting.listener;
+
+import net.tweakcraft.tweakcart.api.event.TweakVehiclePassesSignEvent;
+import net.tweakcraft.tweakcart.api.event.listeners.TweakSignEventListener;
+import net.tweakcraft.tweakcart.cartrouting.model.ActionType;
+import net.tweakcraft.tweakcart.util.BlockUtil;
+import org.bukkit.Material;
+import org.bukkit.material.DetectorRail;
+import org.bukkit.material.Lever;
+import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Created by nick on 25/03/2015.
+ */
+public class CartRoutingEventListener extends TweakSignEventListener {
+
+    private Plugin plugin;
+
+    public CartRoutingEventListener(Plugin plugin){
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void onSignPass(TweakVehiclePassesSignEvent event) {
+        ActionType type = ActionType.getActionType(event.getSign().getLine(0));
+
+        switch(type){
+            case SETDEST:
+                event.getMinecart().setMetadata("Destination", new FixedMetadataValue(plugin, event.getSign().getLine(1)));
+                break;
+            case GETDEST:
+                if (event.getMinecart().hasMetadata("Destination") && event.getMinecart().getLocation().getBlock().getType() == Material.DETECTOR_RAIL) {
+                    if (event.getMinecart().getMetadata("Destination").get(0).asString().equalsIgnoreCase(event.getSign().getLine(1))) {
+                        DetectorRailListener.getInstance().activate(event.getMinecart().getLocation().getBlock().getLocation());
+                    }
+                } else {
+                    if(event.getMinecart().getLocation().getBlock().getType() == Material.DETECTOR_RAIL)
+                        DetectorRailListener.getInstance().activate(event.getMinecart().getLocation().getBlock().getLocation());
+                }
+                break;
+        }
+    }
+}

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/CartRoutingEventListener.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/CartRoutingEventListener.java
@@ -38,9 +38,15 @@ public class CartRoutingEventListener extends TweakSignEventListener {
                 }
                 break;
             case READDEST:
-                if(event.getMinecart().hasMetadata("Destination") && event.getMinecart().getPassenger() instanceof Player)
-                    ((Player) event.getMinecart().getPassenger()).sendMessage("Your are travelling to: " + event.getMinecart().getMetadata("Destination").get(0).asString());
+                if(event.getMinecart().getPassenger() instanceof Player)
+                    if(event.getMinecart().hasMetadata("Destination"))
+                        ((Player) event.getMinecart().getPassenger()).sendMessage("Your are travelling to: " + event.getMinecart().getMetadata("Destination").get(0).asString());
+                    else
+                        ((Player) event.getMinecart().getPassenger()).sendMessage("You have no active destination");
                 break;
+            case CLEARDEST:
+                if(event.getMinecart().hasMetadata("Destination"))
+                    event.getMinecart().removeMetadata("Destination", plugin);
         }
     }
 }

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/CartRoutingEventListener.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/CartRoutingEventListener.java
@@ -34,9 +34,6 @@ public class CartRoutingEventListener extends TweakSignEventListener {
                     if (event.getMinecart().getMetadata("Destination").get(0).asString().equalsIgnoreCase(event.getSign().getLine(1))) {
                         DetectorRailListener.getInstance().activate(event.getMinecart().getLocation().getBlock().getLocation());
                     }
-                } else {
-                    if(event.getMinecart().getLocation().getBlock().getType() == Material.DETECTOR_RAIL)
-                        DetectorRailListener.getInstance().activate(event.getMinecart().getLocation().getBlock().getLocation());
                 }
                 break;
         }

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/DetectorRailListener.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/DetectorRailListener.java
@@ -48,7 +48,9 @@ public class DetectorRailListener extends TweakBlockEventListener implements Lis
         if(event.getNewCurrent() == 0)
             activated.remove(event.getBlock().getLocation());
 
-        if(event.getBlock().getType() == Material.DETECTOR_RAIL && !activated.contains(event.getBlock().getLocation())) {
+        Sign sign = HelperClass.findSign(event.getBlock(), ActionType.GETDEST.getText());
+
+        if(event.getBlock().getType() == Material.DETECTOR_RAIL && !activated.contains(event.getBlock().getLocation()) && sign != null) {
             event.setNewCurrent(0);
         }
     }

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/DetectorRailListener.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/DetectorRailListener.java
@@ -52,18 +52,4 @@ public class DetectorRailListener extends TweakBlockEventListener implements Lis
             event.setNewCurrent(0);
         }
     }
-
-    @Override
-    public void onVehicleBlockChange(TweakVehicleBlockChangeEvent event) {
-        Sign sign = HelperClass.findSign(event.getBlock());
-
-        if (sign != null && ActionType.getActionType(sign.getLine(0)) == ActionType.GETDEST && event.getMinecart().hasMetadata("Destination") && event.getBlock().getType() == Material.DETECTOR_RAIL) {
-            if (event.getMinecart().getMetadata("Destination").get(0).asString().equalsIgnoreCase(sign.getLine(1))) {
-                activated.add(event.getBlock().getLocation());
-            }
-        } else {
-            if(event.getBlock().getType() == Material.DETECTOR_RAIL)
-                activated.add(event.getBlock().getLocation());
-        }
-    }
 }

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/DetectorRailListener.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/listener/DetectorRailListener.java
@@ -1,0 +1,69 @@
+package net.tweakcraft.tweakcart.cartrouting.listener;
+
+import net.tweakcraft.tweakcart.api.event.TweakVehicleBlockChangeEvent;
+import net.tweakcraft.tweakcart.api.event.TweakVehicleBlockRedstoneEvent;
+import net.tweakcraft.tweakcart.api.event.listeners.TweakBlockEventListener;
+import net.tweakcraft.tweakcart.cartrouting.HelperClass;
+import net.tweakcraft.tweakcart.cartrouting.model.ActionType;
+import net.tweakcraft.tweakcart.model.Direction;
+import net.tweakcraft.tweakcart.util.BlockUtil;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.Sign;
+import org.bukkit.entity.Minecart;
+import org.bukkit.event.Listener;
+import org.bukkit.material.DetectorRail;
+import org.bukkit.metadata.FixedMetadataValue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Created by nick on 26/03/2015.
+ */
+public class DetectorRailListener extends TweakBlockEventListener implements Listener {
+
+    private static DetectorRailListener instance = null;
+
+    private Set<Location> activated;
+
+    protected DetectorRailListener(){
+        activated = new HashSet<Location>();
+    }
+
+    public static DetectorRailListener getInstance(){
+        if(instance == null)
+            instance = new DetectorRailListener();
+
+        return instance;
+    }
+
+    public void activate(Location location){
+        activated.add(location);
+    }
+
+    @Override
+    public void onVehicleBlockRedstoneEvent(TweakVehicleBlockRedstoneEvent event) {
+        if(event.getNewCurrent() == 0)
+            activated.remove(event.getBlock().getLocation());
+
+        if(event.getBlock().getType() == Material.DETECTOR_RAIL && !activated.contains(event.getBlock().getLocation())) {
+            event.setNewCurrent(0);
+        }
+    }
+
+    @Override
+    public void onVehicleBlockChange(TweakVehicleBlockChangeEvent event) {
+        Sign sign = HelperClass.findSign(event.getBlock());
+
+        if (sign != null && ActionType.getActionType(sign.getLine(0)) == ActionType.GETDEST && event.getMinecart().hasMetadata("Destination") && event.getBlock().getType() == Material.DETECTOR_RAIL) {
+            if (event.getMinecart().getMetadata("Destination").get(0).asString().equalsIgnoreCase(sign.getLine(1))) {
+                activated.add(event.getBlock().getLocation());
+            }
+        } else {
+            if(event.getBlock().getType() == Material.DETECTOR_RAIL)
+                activated.add(event.getBlock().getLocation());
+        }
+    }
+}

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/model/ActionType.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/model/ActionType.java
@@ -1,0 +1,28 @@
+package net.tweakcraft.tweakcart.cartrouting.model;
+
+/**
+ * Created by nick on 25/03/2015.
+ */
+public enum ActionType {
+    SETDEST("set destination"),
+    GETDEST("get destination");
+
+    private String text;
+
+    private ActionType(String text){
+        this.text = text;
+    }
+
+    public String getText(){
+        return text;
+    }
+
+    public static ActionType getActionType(String text){
+        for(ActionType type : values()){
+            if(type.getText().equalsIgnoreCase(text))
+                return type;
+        }
+
+        return null;
+    }
+}

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/model/ActionType.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/model/ActionType.java
@@ -6,7 +6,8 @@ package net.tweakcraft.tweakcart.cartrouting.model;
 public enum ActionType {
     SETDEST("set destination"),
     GETDEST("get destination"),
-    READDEST("read destination");
+    READDEST("read destination"),
+    CLEARDEST("clear destination");
 
     private String text;
 

--- a/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/model/ActionType.java
+++ b/CartRouting/src/net/tweakcraft/tweakcart/cartrouting/model/ActionType.java
@@ -5,7 +5,8 @@ package net.tweakcraft.tweakcart.cartrouting.model;
  */
 public enum ActionType {
     SETDEST("set destination"),
-    GETDEST("get destination");
+    GETDEST("get destination"),
+    READDEST("read destination");
 
     private String text;
 

--- a/CartRouting/src/plugin.yml
+++ b/CartRouting/src/plugin.yml
@@ -1,0 +1,6 @@
+name: CartRouting
+main: net.tweakcraft.tweakcart.cartrouting.CartRouting
+authors: [nislim]
+website: https://github.com/nislim/TweakCart2Plugins
+version: 0.1
+depend: [TweakCart]

--- a/CartRouting/src/plugin.yml
+++ b/CartRouting/src/plugin.yml
@@ -2,5 +2,5 @@ name: CartRouting
 main: net.tweakcraft.tweakcart.cartrouting.CartRouting
 authors: [nislim]
 website: https://github.com/nislim/TweakCart2Plugins
-version: 0.1
+version: 0.1a
 depend: [TweakCart]

--- a/CartStorage/src/net/tweakcraft/tweakcart/cartstorage/CartStorage.java
+++ b/CartStorage/src/net/tweakcraft/tweakcart/cartstorage/CartStorage.java
@@ -30,6 +30,7 @@ import net.tweakcraft.tweakcart.util.TweakPluginManager;
 import org.bukkit.block.Chest;
 import org.bukkit.entity.minecart.StorageMinecart;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
 
 public class CartStorage extends TweakCartPlugin {
     public static boolean TEST = false;
@@ -51,9 +52,9 @@ public class CartStorage extends TweakCartPlugin {
             if (event.getSign().getBlock().isBlockPowered() || event.getSign().getBlock().isBlockIndirectlyPowered()) {
                 return;
             }
-            if (event.getMinecart() instanceof StorageMinecart) {
-                StorageMinecart storageMinecart = (StorageMinecart) event.getMinecart();
-                Inventory cartInventory = storageMinecart.getInventory();
+            if (event.getMinecart() instanceof InventoryHolder) {
+                InventoryHolder inventoryHolder = (InventoryHolder) event.getMinecart();
+                Inventory cartInventory = inventoryHolder.getInventory();
                 //try
                 //{
                 IntMap[] maps = net.tweakcraft.tweakcart.cartstorage.parser.ItemParser.parseSign(event.getSign(), event.getDirection());


### PR DESCRIPTION
Adds three new sign-commands:
"get destination": Retrieves destination from cart and compare to 2nd line( -> RS signal if correct )
"set destination": Sets destination of cart using 2nd line
"print destination": Prints destination to player chat of player in the minecart

The redstone signal used by the "get destination" sign is applied using a Detector Rail, if a "get destination" sign is near a detector rail the rail is unpowered unless it is the correct destination. If there is no sign near the detector rail it functions as a regular detector rail.
